### PR TITLE
Make very long server names possible

### DIFF
--- a/containers/ddev-router/nginx.tmpl
+++ b/containers/ddev-router/nginx.tmpl
@@ -38,6 +38,9 @@ map $http_upgrade $proxy_connection {
   '' close;
 }
 
+# Apply fix for very long server names
+server_names_hash_bucket_size 128;
+
 # Default dhparam
 # ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Having long server names causes the ddev-router to cease working.
Error message during start:
```nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64```

## How this PR Solves The Problem:

This patch increases server_names_hash_bucket_size to the maximum possible size (128).

## Manual Testing Instructions:

Create a server name longer than 32 characters and you should see, that none of your projects will start again.
